### PR TITLE
WAII-3783: modify_connections() fails when 'updated' attribute is missing

### DIFF
--- a/waii_sdk_py/database/database.py
+++ b/waii_sdk_py/database/database.py
@@ -419,7 +419,8 @@ class DatabaseImpl:
     def modify_connections(
         self, params: ModifyDBConnectionRequest
     ) -> ModifyDBConnectionResponse:
-        self._modify_connection_request(params.updated)
+        if params.updated is not None:
+            self._modify_connection_request(params.updated)
         return self.http_client.common_fetch(
             MODIFY_DB_ENDPOINT, params.__dict__, ModifyDBConnectionResponse
         )


### PR DESCRIPTION
Added a check to ensure the 'params.updated' is not None before iterating over it