### PR TITLE
WAII-3854: Fix tests and test setup docs

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -56,3 +56,5 @@ VALUES
 GRANT ALL PRIVILEGES ON DATABASE waii_sdk_test2 TO waii;
 GRANT ALL PRIVILEGES ON TABLE public.albums TO waii;
 ```
+
+Also ensure you have DB connection to the example snowflake DB - MOVIE_DB. If you do not have this DB connection, consult with a Waii team member for info on this DB connection

--- a/tests/chat_test.py
+++ b/tests/chat_test.py
@@ -84,7 +84,7 @@ class TestChat(unittest.TestCase):
             ask="What's the rating of movies?",
             streaming=False,
             parent_uuid=None,
-            modules=[ChatModule.QUERY, ChatModule.DATA],
+            modules=[ChatModule.QUERY, ChatModule.CHART, ChatModule.DATA],
             module_limit_in_response=2
         )
 
@@ -99,7 +99,7 @@ class TestChat(unittest.TestCase):
             streaming=False,
             parent_uuid=result1.chat_uuid,
             chart_type=ChartType.SUPERSET,
-            modules=[ChatModule.CHART],
+            modules=[ChatModule.CHART, ChatModule.QUERY, ChatModule.DATA],
             module_limit_in_response=1
         )
 

--- a/tests/chat_v2_test.py
+++ b/tests/chat_v2_test.py
@@ -48,11 +48,11 @@ class TestChatV2(unittest.TestCase):
 
     def test_chat_message_chart(self):
         chat_request = ChatRequest(
-            ask="Show me a bar chart of movie ratings",
+            ask="Show me a bar chart for top genres for movies",
             streaming=False,
             parent_uuid=None,
             chart_type=ChartType.SUPERSET,
-            modules=[ChatModule.CHART, ChatModule.QUERY],
+            modules=[ChatModule.CHART, ChatModule.QUERY, ChatModule.DATA],
             module_limit_in_response=2
         )
 
@@ -66,11 +66,11 @@ class TestChatV2(unittest.TestCase):
         self.assertIn(ChatModule.CHART, result.response_selected_fields)
     def test_chat_message_semantic_context(self):
         chat_request = ChatRequest(
-            ask="What tables are available for movie data?",
+            ask="Give top genres for movies",
             streaming=False,
             parent_uuid=None,
             chart_type=None,
-            modules=[ChatModule.DATA],
+            modules=[ChatModule.DATA, ChatModule.QUERY],
             module_limit_in_response=1
         )
 

--- a/tests/chat_v2_test.py
+++ b/tests/chat_v2_test.py
@@ -105,7 +105,7 @@ class TestChatV2(unittest.TestCase):
             ask="What's the rating of movies?",
             streaming=False,
             parent_uuid=None,
-            modules=[ChatModule.QUERY, ChatModule.DATA],
+            modules=[ChatModule.QUERY, ChatModule.CHART, ChatModule.DATA],
             module_limit_in_response=2
         )
 
@@ -120,7 +120,7 @@ class TestChatV2(unittest.TestCase):
             streaming=False,
             parent_uuid=result1.chat_uuid,
             chart_type=ChartType.SUPERSET,
-            modules=[ChatModule.CHART],
+            modules=[ChatModule.CHART, ChatModule.DATA, ChatModule.QUERY],
             module_limit_in_response=1
         )
 

--- a/tests/database_test.py
+++ b/tests/database_test.py
@@ -117,17 +117,22 @@ class TestDatabase(unittest.TestCase):
 
     def test_modify_db_with_search_context_db_content_filter(self):
         db_conn = load_db_conn1()
-        db_conn.db_content_filters = [DBContentFilter(
-            filter_scope = DBContentFilterScope.table,
-            filter_type = DBContentFilterType.include,
-            filter_action_type = DBContentFilterActionType.visibility,
-            pattern='', # empty regex pattern matches all
-            search_context = [
-                SearchContext(db_name='*', schema_name='information_schema', table_name='tables'),
-                SearchContext(db_name='*', schema_name='information_schema', table_name='columns'),
-                SearchContext(db_name='*', schema_name='public', table_name='movies'),
-            ]
-        )]
+        # db_conn.db_content_filters = [DBContentFilter(
+        #     filter_scope = DBContentFilterScope.table,
+        #     filter_type = DBContentFilterType.include,
+        #     filter_action_type = DBContentFilterActionType.visibility,
+        #     pattern='', # empty regex pattern matches all
+        #     search_context = [
+        #         SearchContext(db_name='*', schema_name='information_schema', table_name='tables'),
+        #         SearchContext(db_name='*', schema_name='information_schema', table_name='columns'),
+        #         SearchContext(db_name='*', schema_name='public', table_name='movies'),
+        #     ]
+        # )]
+        db_conn.content_filters = [
+            SearchContext(db_name='*', schema_name='information_schema', table_name='tables'),
+            SearchContext(db_name='*', schema_name='information_schema', table_name='columns'),
+            SearchContext(db_name='*', schema_name='public', table_name='movies'),
+        ]
 
         # modify the connection
         result = WAII.Database.modify_connections(
@@ -135,7 +140,7 @@ class TestDatabase(unittest.TestCase):
         ).connectors
 
         # check if the connection is modified
-        time.sleep(15)
+        time.sleep(30)
 
         # get the catalog
         result = WAII.Database.get_catalogs()
@@ -427,6 +432,12 @@ class TestDatabase(unittest.TestCase):
         WAII.Query.run(
             RunQueryRequest(
                 query="CREATE SCHEMA IF NOT EXISTS test_refresh_db_connection_schema"
+            )
+        )
+
+        WAII.Query.run(
+            RunQueryRequest(
+                query="DROP TABLE IF EXISTS test_refresh_db_connection_schema.test_refresh_db_connection"
             )
         )
 

--- a/tests/database_test.py
+++ b/tests/database_test.py
@@ -117,22 +117,17 @@ class TestDatabase(unittest.TestCase):
 
     def test_modify_db_with_search_context_db_content_filter(self):
         db_conn = load_db_conn1()
-        # db_conn.db_content_filters = [DBContentFilter(
-        #     filter_scope = DBContentFilterScope.table,
-        #     filter_type = DBContentFilterType.include,
-        #     filter_action_type = DBContentFilterActionType.visibility,
-        #     pattern='', # empty regex pattern matches all
-        #     search_context = [
-        #         SearchContext(db_name='*', schema_name='information_schema', table_name='tables'),
-        #         SearchContext(db_name='*', schema_name='information_schema', table_name='columns'),
-        #         SearchContext(db_name='*', schema_name='public', table_name='movies'),
-        #     ]
-        # )]
-        db_conn.content_filters = [
-            SearchContext(db_name='*', schema_name='information_schema', table_name='tables'),
-            SearchContext(db_name='*', schema_name='information_schema', table_name='columns'),
-            SearchContext(db_name='*', schema_name='public', table_name='movies'),
-        ]
+        db_conn.db_content_filters = [DBContentFilter(
+            filter_scope = DBContentFilterScope.table,
+            filter_type = DBContentFilterType.include,
+            filter_action_type = DBContentFilterActionType.visibility,
+            pattern='', # empty regex pattern matches all
+            search_context = [
+                SearchContext(db_name='*', schema_name='information_schema', table_name='tables'),
+                SearchContext(db_name='*', schema_name='information_schema', table_name='columns'),
+                SearchContext(db_name='*', schema_name='public', table_name='movies'),
+            ]
+        )]
 
         # modify the connection
         result = WAII.Database.modify_connections(

--- a/tests/multi_tenant_client_test.py
+++ b/tests/multi_tenant_client_test.py
@@ -34,7 +34,7 @@ class MultiTenantClientTest(unittest.TestCase):
         assert result.uuid is not None
         assert len(result.detailed_steps) > 0
         assert len(result.query) > 0
-        assert "sdk_test.public.movies" in result.query.lower()
+        assert "public.movies" in result.query.lower()
         assert len(result.tables) > 0
 
         params = LikeQueryRequest(query_uuid=result.uuid, liked=True)
@@ -76,7 +76,7 @@ class MultiTenantClientTest(unittest.TestCase):
         result = self.chinook_waii.query.run(params)
         self.assertIsInstance(result, GetQueryResultResponse)
         assert len(result.column_definitions) > 0
-        assert "...And" in str(result.rows[0])
+        assert "21" in str(result.rows[0])
 
     def test_legacy_generate(self):
         WAII.Database.activate_connection(self.movie_conn.key)
@@ -88,7 +88,7 @@ class MultiTenantClientTest(unittest.TestCase):
         assert result.uuid is not None
         assert len(result.detailed_steps) > 0
         assert len(result.query) > 0
-        assert "sdk_test." in result.query.lower()
+        assert "public.movies" in result.query.lower()
         assert len(result.tables) > 0
 
         params = LikeQueryRequest(query_uuid=result.uuid, liked=True)

--- a/tests/query_test.py
+++ b/tests/query_test.py
@@ -11,20 +11,20 @@ class TestQuery(unittest.TestCase):
         self.result = result
         pg_connector = None
         for connector in result.connectors:
-            if connector.db_type == "postgresql":
+            if connector.db_type == "postgresql" and connector.database == 'waii_sdk_test':
                 pg_connector = connector
                 break
 
         WAII.Database.activate_connection(pg_connector.key)
 
     def test_generate(self):
-        params = QueryGenerationRequest(ask="How many tables are there?", use_cache=False)
+        params = QueryGenerationRequest(ask="How many movies are there?", use_cache=False)
         result = WAII.Query.generate(params)
         self.assertIsInstance(result, GeneratedQuery)
         assert result.uuid is not None
         assert len(result.detailed_steps) > 0
         assert len(result.query) > 0
-        assert 'information_schema' in result.query.lower()
+        assert 'public.movies' in result.query.lower()
         assert len(result.tables) > 0
         assert hasattr(result.confidence_score, "confidence_value")
 
@@ -68,11 +68,11 @@ class TestQuery(unittest.TestCase):
         assert len(result.summary) > 0
 
     def test_transcode(self):
-        params = TranscodeQueryRequest(source_dialect="mysql", target_dialect="postgres", source_query="SELECT 42")
+        params = TranscodeQueryRequest(source_dialect="mysql", target_dialect="postgres", source_query="SELECT * FROM movies")
         result = WAII.Query.transcode(params)
         self.assertIsInstance(result, GeneratedQuery)
         assert len(result.query) > 0
-        assert '42' in result.query.lower()
+        assert 'movies' in result.query.lower()
 
     def test_like_query(self):
         params = LikeQueryRequest(liked=True,ask="like test ask", query="SELECT S_STATE FROM STORE",

--- a/tests/semantic_context_test.py
+++ b/tests/semantic_context_test.py
@@ -8,7 +8,7 @@ class TestSemanticContext(unittest.TestCase):
         WAII.initialize(url="http://localhost:9859/api/")
         result = WAII.Database.get_connections()
         self.result = result
-        WAII.Database.activate_connection(result.connectors[10].key)
+        WAII.Database.activate_connection(result.connectors[2].key)
 
     def test_modify_semantic_context(self):
         # Define test parameters


### PR DESCRIPTION
2 tests fail because of [WAII-3912](https://waii-ai.atlassian.net/browse/WAII-3912)

```
(waii-sdk-py) sparshsarode@Mac waii-sdk-py % pytest
=============================================================================== test session starts ================================================================================
platform darwin -- Python 3.10.16, pytest-7.4.4, pluggy-1.5.0
rootdir: /Users/sparshsarode/Work/Waii/waii-sdk-py
collected 55 items                                                                                                                                                                 

tests/async_client_test.py F.                                                                                                                                                [  3%]
tests/chat_test.py ....                                                                                                                                                      [ 10%]
tests/chat_v2_test.py .....                                                                                                                                                  [ 20%]
tests/database_test.py ...............                                                                                                                                       [ 47%]
tests/history_test.py ..                                                                                                                                                     [ 50%]
tests/multi_tenant_client_test.py ........                                                                                                                                   [ 65%]
tests/multi_tenant_semantic_context_test.py ..                                                                                                                               [ 69%]
tests/query_test.py ..F.....                                                                                                                                                 [ 83%]
tests/semantic_context_test.py ...                                                                                                                                           [ 89%]
tests/waii_basemodel_test.py ......                                                                                                                                          [100%]
```

Test with both python 3.10 and 3.9