### PR TITLE
WAII-4062: Sample column values by default in SDK

### DIFF
--- a/doc/docs/database-module.md
+++ b/doc/docs/database-module.md
@@ -55,6 +55,7 @@ To add connection, you need to create `DBConnection` Object, which include the f
 - `db_alias`: alias of the database.
 - `host_alias`: alias of the host.
 - `user_alias`: alias of the user.
+- `push`: Waii, by default, uses pull-based connections - it pulls table definitions from your database. Set this value to true if, instead, you want to manually give the table definitions using `Database.update_table_definition`
 
 (Deprecated field)
 - `alias`: Alias of the connection, which can be used to refer the connection in the query. If it is not set, then we will generate a key based on the connection details. This allows you to add multiple connections to the same database with different alias, you can set different db_content_filters, etc.
@@ -587,6 +588,36 @@ table_definition =  TableDefinition(
                 ColumnDefinition(name="col2", type="int"),
                 ColumnDefinition(name="col3", type="int"),
                 ]
+            )
+update_table_req = UpdateTableDefinitionRequest(updated_tables = [table_definition]
+                                                )
+result = WAII.Database.update_table_definition(update_table_req)
+```
+
+If you want to specify DDL command used to create the view for more context and help Waii understand it better, you can use the `ddl` field. It can be particularly useful when the DDL used to create the view has more meaningful context than the table and column names as shown:
+```python
+table_definition =  TableDefinition(
+            name=TableName(
+                database_name="db1", schema_name="schema2", table_name="table1"
+            ),
+            columns=[
+                ColumnDefinition(name="col1", type="string"),
+                ColumnDefinition(name="col2", type="string"),
+                ColumnDefinition(name="col3", type="string"),
+                ColumnDefinition(name="col4", type="string"),
+                ],
+            ddl="""
+CREATE OR REPLACE VIEW table1 AS
+SELECT
+    a.AuthorName as col1,
+    a.Country as col2,
+    b.Title as col3,
+    b.PublicationYear as col4
+FROM
+    Authors a
+JOIN
+    Books b ON a.AuthorID = b.AuthorID;
+            """
             )
 update_table_req = UpdateTableDefinitionRequest(updated_tables = [table_definition]
                                                 )

--- a/tests/database_test.py
+++ b/tests/database_test.py
@@ -154,6 +154,7 @@ class TestDatabase(unittest.TestCase):
                     and self.db_conn.database == conn.database
                     and self.db_conn.username == conn.username
             ):
+                assert conn.sample_col_values == True
                 result = WAII.Database.modify_connections(
                     ModifyDBConnectionRequest(removed=[conn.key])
                 ).connectors

--- a/waii_sdk_py/database/database.py
+++ b/waii_sdk_py/database/database.py
@@ -234,7 +234,7 @@ class DBConnection(WaiiBaseModel):
     host: Optional[str] = None
     port: Optional[int] = None
     parameters: Optional[Dict[str, Any]] = None
-    sample_col_values: Optional[bool] = None
+    sample_col_values: Optional[bool] = True
     push:Optional[bool] = False
     db_content_filters: Optional[List[DBContentFilter]] = None
     embedding_model: Optional[str] = None


### PR DESCRIPTION
SDK should use sample column values by default for DB connection creations.